### PR TITLE
Fixed the Invalid User Bug

### DIFF
--- a/src/main/java/com/beanbeanjuice/utility/command/usage/Usage.java
+++ b/src/main/java/com/beanbeanjuice/utility/command/usage/Usage.java
@@ -176,7 +176,6 @@ public class Usage {
      */
     @NotNull
     private Boolean isLink(@NotNull String string) {
-
         try {
             new URL(string).toURI();
             return true;
@@ -214,13 +213,13 @@ public class Usage {
     private Boolean isUser(@NotNull String userID) {
         userID = userID.replace("<@!", "");
         userID = userID.replace(">", "");
+        userID = userID.replace("<@", "");
 
         try {
             CafeBot.getJDA().getUserById(userID);
         } catch (NumberFormatException e) {
             return false;
         }
-
         return true;
     }
 
@@ -232,6 +231,7 @@ public class Usage {
     @NotNull
     private Boolean isRole(@NotNull Guild guild, @NotNull String roleID) {
         roleID = roleID.replace("<@&", "");
+        roleID = roleID.replace("<@", "");
         roleID = roleID.replace(">", "");
 
         try {
@@ -239,7 +239,6 @@ public class Usage {
         } catch (NumberFormatException e) {
             return false;
         }
-
         return true;
     }
 

--- a/src/main/java/com/beanbeanjuice/utility/helper/GeneralHelper.java
+++ b/src/main/java/com/beanbeanjuice/utility/helper/GeneralHelper.java
@@ -132,6 +132,7 @@ public class GeneralHelper {
     @Nullable
     public User getUser(@NotNull String userID) {
         userID = userID.replace("<@!", "");
+        userID = userID.replace("<@", ""); // Edge Case for Mobile
         userID = userID.replace(">", "");
 
         return CafeBot.getJDA().getUserById(userID);
@@ -146,6 +147,7 @@ public class GeneralHelper {
     @Nullable
     public Role getRole(@NotNull Guild guild, @NotNull String roleID) {
         roleID = roleID.replace("<@&", "");
+        roleID = roleID.replace("<@", "");
         roleID = roleID.replace(">", "");
 
         return guild.getRoleById(roleID);

--- a/src/main/java/com/beanbeanjuice/utility/listener/Listener.java
+++ b/src/main/java/com/beanbeanjuice/utility/listener/Listener.java
@@ -80,7 +80,7 @@ public class Listener extends ListenerAdapter {
         try {
             prefix = CafeBot.getGuildHandler().getCustomGuild(event.getGuild().getId()).getPrefix();
         } catch (NullPointerException e) {
-            event.getChannel().sendMessage(startingUpEmbed()).queue();
+            //event.getChannel().sendMessage(startingUpEmbed()).queue();
             return;
         }
 


### PR DESCRIPTION
Fixes #142.

Changes Proposed in this Pull Request:
- Fixes the issue where on mobile, Discord mentions use `<@69312322199370753>` instead of `<@!449320492830943>` like on Desktop.
- Removed the message that is sent when a "command" is sent while it is starting up. This is because the message was sent regardless of if it was a command or not.