### PR TITLE
Fixed Twitch Channels Not Refreshing on a Rejoin

### DIFF
--- a/src/main/java/com/beanbeanjuice/utility/guild/GuildHandler.java
+++ b/src/main/java/com/beanbeanjuice/utility/guild/GuildHandler.java
@@ -316,21 +316,31 @@ public class GuildHandler {
      */
     @NotNull
     public Boolean removeGuild(@NotNull String guildID) {
-
         Connection connection = CafeBot.getSQLServer().getConnection();
         String arguments = "DELETE FROM cafeBot.guild_information " +
                 "WHERE guild_id = (?);";
 
         try {
             PreparedStatement statement = connection.prepareStatement(arguments);
-            statement.setString(1, guildID);
-
+            statement.setLong(1, Long.parseLong(guildID));
             statement.execute();
-            return true;
         } catch (SQLException e) {
-            CafeBot.getLogManager().log(GuildHandler.class, LogLevel.ERROR, "Unable to reach the SQL database.");
+            CafeBot.getLogManager().log(GuildHandler.class, LogLevel.ERROR, "Error Removing Guild: " + e.getMessage());
             return false;
         }
+
+        arguments = "DELETE FROM cafeBot.guild_twitch WHERE guild_id = (?);";
+
+        try {
+            PreparedStatement statement = connection.prepareStatement(arguments);
+            statement.setLong(1, Long.parseLong(guildID));
+            statement.execute();
+        } catch (SQLException e) {
+            CafeBot.getLogManager().log(GuildHandler.class, LogLevel.WARN, "Error Removing Guild's Twitch: " + e.getMessage());
+            return false;
+        }
+
+        return true;
     }
 
     /**
@@ -340,7 +350,6 @@ public class GuildHandler {
      */
     @NotNull
     public Boolean removeGuild(@NotNull Guild guild) {
-
         if (removeGuild(guild.getId())) {
             guildDatabase.remove(guild.getId());
             return true;

--- a/src/main/java/com/beanbeanjuice/utility/logger/LogManager.java
+++ b/src/main/java/com/beanbeanjuice/utility/logger/LogManager.java
@@ -45,7 +45,7 @@ public class LogManager {
 
         log(LogManager.class, LogLevel.INFO, "Starting the Uncaught Exception Handler", true, false);
         Thread.setDefaultUncaughtExceptionHandler((thread, exception) -> {
-            CafeBot.getLogManager().log(thread.getClass(), LogLevel.WARN, exception.getMessage());
+            CafeBot.getLogManager().log(thread.getClass(), LogLevel.WARN, "Unhandled Exception: " + exception.getMessage());
         });
     }
 


### PR DESCRIPTION
Fixes #267.

Changes Proposed in this Pull Request:
- Now, when a twitch channel is added, and a bot is kicked and re-added, the twitch channels in the `MySQL` database are removed as well.