### PR TITLE
Bind to Current Voice Channel

### DIFF
--- a/src/main/java/com/beanbeanjuice/command/moderation/voicebind/VoiceRoleBindCommand.java
+++ b/src/main/java/com/beanbeanjuice/command/moderation/voicebind/VoiceRoleBindCommand.java
@@ -6,8 +6,10 @@ import com.beanbeanjuice.utility.command.ICommand;
 import com.beanbeanjuice.utility.command.usage.Usage;
 import com.beanbeanjuice.utility.command.usage.categories.CategoryType;
 import com.beanbeanjuice.utility.command.usage.types.CommandType;
+import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
+import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
 
 import java.util.ArrayList;
 
@@ -21,22 +23,44 @@ public class VoiceRoleBindCommand implements ICommand {
     @Override
     public void handle(CommandContext ctx, ArrayList<String> args, User user, GuildMessageReceivedEvent event) {
 
+        // Checking if the user running this command is an administrator.
         if (!CafeBot.getGeneralHelper().isAdministrator(event.getMember(), event)) {
             return;
         }
 
-        String guildID = event.getGuild().getId();
-        String voiceChannelID = args.get(0);
-        String roleID = CafeBot.getGeneralHelper().getRole(event.getGuild(), args.get(1)).getId();
+        // Checking if the member is in a voice channel.
+        if (!event.getMember().getVoiceState().inVoiceChannel()) {
+            event.getChannel().sendMessage(CafeBot.getGeneralHelper().errorEmbed(
+                    "Not In Voice Channel",
+                    "You must be in a voice channel to use this command."
+            )).queue();
+            return;
+        }
 
-        // Checking if it has not been binded.
+        String guildID = event.getGuild().getId();
+        String voiceChannelID = event.getMember().getVoiceState().getChannel().getId();
+        String roleID = CafeBot.getGeneralHelper().getRole(event.getGuild(), args.get(0)).getId();
+
+        // Checking if it has not been bound.
         if (!CafeBot.getVoiceChatRoleBindHandler().getBoundRoles(guildID, voiceChannelID).contains(roleID)) {
             if (CafeBot.getVoiceChatRoleBindHandler().bind(guildID, voiceChannelID, roleID)) {
                 event.getChannel().sendMessage(CafeBot.getGeneralHelper().successEmbed(
                         "Role Bound to Voice Channel",
-                        event.getGuild().getRoleById(roleID).getAsMention() + " has been successfully bound to `" +
-                                voiceChannelID + "` (" + event.getGuild().getVoiceChannelById(voiceChannelID).getAsMention() + ")!"
+                        event.getGuild().getRoleById(roleID).getAsMention() + " has been successfully bound to " +
+                                event.getGuild().getVoiceChannelById(voiceChannelID).getAsMention() + "!"
                 )).queue();
+
+                // Adding the role to current VC members.
+                try {
+                    for (Member voiceMember : event.getGuild().getVoiceChannelById(voiceChannelID).getMembers()) {
+                        event.getGuild().addRoleToMember(voiceMember, event.getGuild().getRoleById(roleID)).queue();
+                    }
+                } catch (InsufficientPermissionException e) {
+                    event.getChannel().sendMessage(CafeBot.getGeneralHelper().errorEmbed(
+                            "Error Adding Roles",
+                            "There was an error adding roles to existing users: " + e.getMessage()
+                    )).queue();
+                }
                 return;
             }
             event.getChannel().sendMessage(CafeBot.getGeneralHelper().errorEmbed(
@@ -46,13 +70,25 @@ public class VoiceRoleBindCommand implements ICommand {
             return;
         }
 
-        // If it has been binded, remove it.
+        // If it has been bound, remove it.
         if (CafeBot.getVoiceChatRoleBindHandler().unBind(guildID, voiceChannelID, roleID)) {
             event.getChannel().sendMessage(CafeBot.getGeneralHelper().successEmbed(
                     "Role Unbound from Voice Channel",
-                    event.getGuild().getRoleById(roleID).getAsMention() + " has been successfully unbound from `" +
-                            voiceChannelID + "` (" + event.getGuild().getVoiceChannelById(voiceChannelID).getAsMention() + ")!"
+                    event.getGuild().getRoleById(roleID).getAsMention() + " has been successfully unbound from "
+                            + event.getGuild().getVoiceChannelById(voiceChannelID).getAsMention() + "!"
             )).queue();
+
+            // Adding the role to current VC members.
+            try {
+                for (Member voiceMember : event.getGuild().getVoiceChannelById(voiceChannelID).getMembers()) {
+                    event.getGuild().removeRoleFromMember(voiceMember, event.getGuild().getRoleById(roleID)).queue();
+                }
+            } catch (InsufficientPermissionException e) {
+                event.getChannel().sendMessage(CafeBot.getGeneralHelper().errorEmbed(
+                        "Error Removing Roles",
+                        "There was an error removing roles from existing users: " + e.getMessage()
+                )).queue();
+            }
             return;
         }
 
@@ -77,6 +113,8 @@ public class VoiceRoleBindCommand implements ICommand {
         arrayList.add("bindrole");
         arrayList.add("role-bind");
         arrayList.add("rolebind");
+        arrayList.add("vc-role-bind");
+        arrayList.add("vc-bind");
         return arrayList;
     }
 
@@ -87,13 +125,12 @@ public class VoiceRoleBindCommand implements ICommand {
 
     @Override
     public String exampleUsage(String prefix) {
-        return "`" + prefix + "bind-voice 841880122297417738 @GamingVoice`";
+        return "`" + prefix + "bind-voice @GamingVoice`";
     }
 
     @Override
     public Usage getUsage() {
         Usage usage = new Usage();
-        usage.addUsage(CommandType.VOICECHANNEL, "Voice Channel ID", true);
         usage.addUsage(CommandType.ROLE, "Role Mention/ID", true);
         return usage;
     }

--- a/src/main/java/com/beanbeanjuice/utility/sections/moderation/voicechat/VoiceChatListener.java
+++ b/src/main/java/com/beanbeanjuice/utility/sections/moderation/voicechat/VoiceChatListener.java
@@ -22,21 +22,24 @@ public class VoiceChatListener extends ListenerAdapter {
 
     @Override
     public void onGuildVoiceMove(@NotNull GuildVoiceMoveEvent event) {
-        ArrayList<String> roleIDs = new ArrayList<>(CafeBot.getVoiceChatRoleBindHandler().getBoundRoles(event.getGuild().getId(), event.getChannelLeft().getId()));
+        ArrayList<String> fromIDs = new ArrayList<>(CafeBot.getVoiceChatRoleBindHandler().getBoundRoles(event.getGuild().getId(), event.getChannelLeft().getId()));
+        ArrayList<String> toIDs = new ArrayList<>(CafeBot.getVoiceChatRoleBindHandler().getBoundRoles(event.getGuild().getId(), event.getChannelJoined().getId()));
 
-        for (String roleID : roleIDs) {
+        // Get bound roles from the channel left and compare it to the bound roles from the channel joined.
+        // Remove any roles from the 'from' array list that match.
+        fromIDs.removeAll(toIDs);
+
+        for (String roleID : fromIDs) {
             try {
                 event.getGuild().removeRoleFromMember(event.getMember(), event.getGuild().getRoleById(roleID)).queue();
             } catch (NullPointerException | IllegalArgumentException e) {
-                CafeBot.getVoiceChatRoleBindHandler().unBind(event.getGuild().getId(), event.getChannelLeft().getId(), roleID);
+                CafeBot.getVoiceChatRoleBindHandler().unBind(event.getGuild().getId(), event.getChannelJoined().getId(), roleID);
             } catch (InsufficientPermissionException e) {
                 CafeBot.getGuildHandler().getCustomGuild(event.getGuild()).log(new VoiceRoleBindCommand(), LogLevel.ERROR, "Insufficient Permissions", "The role I am trying to remove from a user is higher than the bot.");
             }
         }
 
-        roleIDs = new ArrayList<>(CafeBot.getVoiceChatRoleBindHandler().getBoundRoles(event.getGuild().getId(), event.getChannelJoined().getId()));
-
-        for (String roleID : roleIDs) {
+        for (String roleID : toIDs) {
             try {
                 event.getGuild().addRoleToMember(event.getMember(), event.getGuild().getRoleById(roleID)).queue();
             } catch (NullPointerException | IllegalArgumentException e) {


### PR DESCRIPTION
Fixes #309.

Changes Proposed in this Pull Request:
- The `get-binds` and `bind-role` commands now require you to be in the actual voice channel.
- The handling method for adding/removing roles has been revamped. It now only removes roles that need to be removed.