### PR TITLE
Made the Eight Ball Command More Legible

### DIFF
--- a/src/main/java/com/beanbeanjuice/command/games/EightBallCommand.java
+++ b/src/main/java/com/beanbeanjuice/command/games/EightBallCommand.java
@@ -3,6 +3,8 @@ package com.beanbeanjuice.command.games;
 import com.beanbeanjuice.utility.command.CommandCategory;
 import com.beanbeanjuice.utility.command.ICommand;
 import com.beanbeanjuice.utility.helper.Helper;
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
@@ -19,10 +21,18 @@ public class EightBallCommand implements ICommand {
 
     @Override
     public void handle(@NotNull SlashCommandInteractionEvent event) {
-        event.getHook().sendMessageEmbeds(Helper.successEmbed(
-                "8 Ball",
-                getAnswer()
-        )).queue();
+        event.getHook().sendMessageEmbeds(
+                getAnswerEmbed(event.getOption("question").getAsString(), getAnswer())
+        ).queue();
+    }
+
+    @NotNull
+    private MessageEmbed getAnswerEmbed(@NotNull String question, @NotNull String answer) {
+        return new EmbedBuilder()
+                .setDescription("\"" + question + "\"")
+                .addField("My Mystical Answer", "\"" + answer + "\"", false)
+                .setColor(Helper.getRandomColor())
+                .build();
     }
 
     @NotNull


### PR DESCRIPTION
# Description

*The `/8-ball` command was not legible before. It has now been fixed.*

BEFORE: 
![image](https://user-images.githubusercontent.com/64740551/178629678-fb2c669a-2225-4c56-9fe2-ccab0fba7dcc.png)

AFTER:
![image](https://user-images.githubusercontent.com/64740551/178629707-fa2097ee-55e4-48a4-abe5-d364fcfcc3d3.png)

Fixes #466

## Type of Change

- [ ] Bug Fix (Small Non-Code Breaking Issue)
- [ ] Bug Fix (Critical Code Breaking Issue)
- [ ] Feature (Something New Added to the Code)
- [x] Improvement (Improving An Existing Section of Code)
- [ ] Documentation Update

## Changes

- [x] Internal Code
- [ ] Documentation
- [ ] Other: _____

**Test Configuration**:
* Hardware:
    - CPU: AMD Ryzen 7 3800x @ 4.125 Ghz
    - GPU: Nvidia RTX 3080
    - RAM: 32 GB DDR4 @ 3600 Mhz
* SDK: Java Oracle 16

# Checklist:

- [x] The code follows the style [guidlines](https://github.com/beanbeanjuice/cafeBot/blob/master/CONTRIBUTING.md).
- [x] A self-review of the code was performed in GitHub.
- [x] Appropriate comments were added in the code.
- [x] Appropriate changes have been made to the documentation.
- [x] Appropriate changes have been made to the `README.md` file.
- [x] No warnings are produced when the code is run.
- [x] Appropriate tests exist for this pull request.
- [x] New and existing Maven CI tests have passed.
- [x] The pull request is properly merging into the correct branch.
- [x] All existing local code has been pushed to the GitHub repository.
- [x] Changes have been documented in the current draft [cafeBot Releases](https://github.com/beanbeanjuice/cafeBot/releases) update.