### PR TITLE
Fixed the Midnight Log Issue

### DIFF
--- a/src/main/java/com/beanbeanjuice/utility/logging/LogManager.java
+++ b/src/main/java/com/beanbeanjuice/utility/logging/LogManager.java
@@ -64,19 +64,22 @@ public class LogManager {
 
         // Setting the current log file time.
         logFileTime = time.format("MM-dd-yyyy");
+        boolean newDirectoryCreated = false;
 
         File file = new File(filePath);
         if (!file.exists())
-            file.mkdir();
+            newDirectoryCreated = file.mkdir();
 
         compressOldLogs();
 
         // If the log file already exists, it doesn't need to make a new one.
-        if (!createLogFile(filePath)) {
-            log(this.getClass(), LogLevel.INFO, "Log for today has already been created.");
-        } else {
-            log(this.getClass(), LogLevel.OKAY, "Created Log File!");
-        }
+        if (!createLogFile(filePath))
+            log(LogManager.class, LogLevel.INFO, "Log for today has already been created.");
+        else
+            log(LogManager.class, LogLevel.OKAY, "Created Log File!");
+
+        if (!newDirectoryCreated)
+            log(LogManager.class, LogLevel.WARN, "No new directory has been created...");
     }
 
     private void logStackTrace(@NotNull Throwable exception) {
@@ -317,10 +320,8 @@ public class LogManager {
     public void log(@NotNull Class<?> c, @NotNull LogLevel logLevel, @NotNull String message,
                     @NotNull Boolean logToWebhook, @NotNull Boolean logToLogChannel, @Nullable Throwable exception) {
 
-        if (!time.format("MM-dd-yyyy").equals(logFileTime)) {
-            log(this.getClass(), LogLevel.INFO, "New day... creating new log file.", true, true);
+        if (!time.format("MM-dd-yyyy").equals(logFileTime))
             checkFiles();
-        }
 
         Logger logger = LoggerFactory.getLogger(c);
 


### PR DESCRIPTION
# Description

*There was an error with the `LogManager` that caused the bot to stop working at midnight `UTC`. This was because of some error with JDA and an incorrect webhook token. This has now been fixed.*

Fixes #493

## Type of Change

- [ ] Bug Fix (Small Non-Code Breaking Issue)
- [x] Bug Fix (Critical Code Breaking Issue)
- [ ] Feature (Something New Added to the Code)
- [ ] Improvement (Improving An Existing Section of Code)
- [ ] Documentation Update
- [ ] Security Vulnerability

## Changes

- [x] Internal Code
- [ ] Documentation
- [ ] Other: _____

**Test Configuration**:
* Hardware:
    - CPU: AMD Ryzen 7 3800x @ 4.125 Ghz
    - GPU: Nvidia RTX 3080
    - RAM: 32 GB DDR4 @ 3600 Mhz
* JDK: Java Oracle OpenJDK 16

# Checklist:

- [x] This pull request has been linked to the appropriate issue on GitHub. (Use the development section on the right.)
- [x] The code follows the style [guidelines](https://github.com/beanbeanjuice/cafeBot/blob/master/CONTRIBUTING.md).
- [x] A self-review of the code was performed on GitHub.
- [x] Appropriate comments and javadocs were added in your code.
- [x] Appropriate changes have been made to the documentation.
- [x] Appropriate changes have been made to the `README.md` file.
- [x] No warnings are produced when the code is run.
- [x] Appropriate tests exist for this pull request.
- [x] New and existing Maven CI tests have passed.
- [x] The pull request is properly merging into the correct branch.
- [x] All existing local code has been pushed to the GitHub repository.
- [x] Changes have been documented in the current draft [cafeBot Releases](https://github.com/beanbeanjuice/cafeBot/releases) update.