### PR TITLE
Fixed the Clear-Chat Command

### DIFF
--- a/src/main/java/com/beanbeanjuice/command/moderation/ClearChatCommand.java
+++ b/src/main/java/com/beanbeanjuice/command/moderation/ClearChatCommand.java
@@ -2,122 +2,43 @@ package com.beanbeanjuice.command.moderation;
 
 import com.beanbeanjuice.utility.command.CommandCategory;
 import com.beanbeanjuice.utility.command.ICommand;
-import com.beanbeanjuice.utility.handler.guild.CustomGuild;
-import com.beanbeanjuice.utility.handler.guild.GuildHandler;
 import com.beanbeanjuice.utility.helper.Helper;
-import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
-import net.dv8tion.jda.api.entities.Message;
-import net.dv8tion.jda.api.entities.MessageEmbed;
-import net.dv8tion.jda.api.entities.TextChannel;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
-import net.dv8tion.jda.api.exceptions.ErrorHandler;
-import net.dv8tion.jda.api.exceptions.ErrorResponseException;
+import net.dv8tion.jda.api.exceptions.InsufficientPermissionException;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.awt.*;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Timer;
-import java.util.TimerTask;
 
 /**
  * An {@link ICommand} used to clear a {@link net.dv8tion.jda.api.entities.TextChannel TextChannel}.
  *
  * @author beanbeanjuice
+ * @since v3.1.1
  */
 public class ClearChatCommand implements ICommand {
 
     @Override
     public void handle(@NotNull SlashCommandInteractionEvent event) {
-        if (GuildHandler.getCustomGuild(event.getGuild()).containsTextChannelDeletingMessages(event.getTextChannel())) {
-            event.getHook().sendMessageEmbeds(alreadyDeletingMessagesEmbed()).queue();
-            return;
-        }
-
         int amount = event.getOption("amount").getAsInt();
 
-        // Send message that it is deleting, save the message and exclude it from being deleted.
-        event.getHook().sendMessageEmbeds(beginDeletionEmbed(amount)).queue(e -> {
-
-            // +1 is needed because it removes the one just sent.
-            event.getChannel().getHistory().retrievePast(amount+1).queue(messages -> {
-                messages.remove(e);
-                startMessagesDeletions(new ArrayList<>(messages), e);
-            });
-        });
-    }
-
-    private MessageEmbed beginDeletionEmbed(@NotNull Integer amount) {
-        return new EmbedBuilder()
-                .setTitle("Starting Deletion")
-                .setColor(Helper.getRandomColor())
-                .setDescription("Deleting `" + amount + "` messages. This might take a while.")
-                .build();
-    }
-
-    private MessageEmbed alreadyDeletingMessagesEmbed() {
-        return new EmbedBuilder()
-                .setTitle("Already Deleting Messages")
-                .setDescription("You are already deleting messages in this channel. " +
-                        "Please use this command in another channel or wait for this action to stop.")
-                .setColor(Color.red)
-                .build();
-    }
-
-    private void startMessagesDeletions(@NotNull ArrayList<Message> messages, @NotNull Message deletionMessage) {
-
-        Collections.reverse(messages);
-
-        TextChannel textChannel = deletionMessage.getTextChannel();
-        int messageCount = messages.size();
-        CustomGuild guild = GuildHandler.getCustomGuild(deletionMessage.getGuild());
-
-        guild.addTextChannelToDeletingMessages(deletionMessage.getTextChannel());
-
-        Timer timer = new Timer();
-        TimerTask timerTask = new TimerTask() {
-
-            int count = 0;
-
-            @Override
-            public void run() {
-
-                Message message = messages.get(count++);
-
-                // Go through each message and delete it individually. Ignores the error response it might get.
-                message.delete().queue(null, new ErrorHandler().ignore(ErrorResponseException.class));
-
-                // If the messages is empty, cancel it.
-                if (count == messageCount) {
-                    timer.cancel(); // Cancel the timer.
-                    textChannel.sendMessageEmbeds(completedDeletionEmbed(messageCount)).queue(e -> {
-                        try {
-                            // Makes the thread sleep for 10 seconds.
-                            Thread.sleep(10000);
-                        } catch (InterruptedException ignored) {}
-
-                        // Removes the current channel from channels having current deletions in it.
-                        guild.removeTextChannelFromDeletingMessages(e.getTextChannel());
-                        e.delete().queue();
-                    });
-                }
-            }
-        };
-        timer.scheduleAtFixedRate(timerTask, 0, 50);
-    }
-
-    private MessageEmbed completedDeletionEmbed(@NotNull Integer count) {
-        return new EmbedBuilder()
-                .setTitle("Completed Deletion")
-                .setDescription("Successfully deleted `" + count + "` messages. " +
-                        "There might be a time lag for deleting messages. This message will disappear once " +
-                        "all of the messages have been successfully deleted from discord.")
-                .setColor(Helper.getRandomColor())
-                .build();
+        try {
+            event.getMessageChannel().getIterableHistory().takeAsync(amount)
+                    .thenApply(messages -> event.getChannel().purgeMessages(messages));
+            event.getHook().sendMessageEmbeds(Helper.successEmbed(
+                    "Deleting Messages",
+                    "Attempting to delete `" + amount + "` messages. This might take a while..."
+            )).queue();
+        } catch (InsufficientPermissionException e) {
+            event.getHook().sendMessageEmbeds(Helper.errorEmbed(
+                    "Error Deleting Messages",
+                    "There was an error deleting your messages. The " +
+                            "bot may have insufficient permissions. `" + e.getMessage() + "`"
+            )).queue();
+        }
     }
 
     @NotNull
@@ -136,8 +57,7 @@ public class ClearChatCommand implements ICommand {
     @Override
     public ArrayList<OptionData> getOptions() {
         ArrayList<OptionData> options = new ArrayList<>();
-        options.add(new OptionData(OptionType.INTEGER, "amount", "The number of messages to clear.", true, false)
-                .setRequiredRange(1, 99));
+        options.add(new OptionData(OptionType.INTEGER, "amount", "The number of messages to clear.", true));
         return options;
     }
 

--- a/src/main/java/com/beanbeanjuice/command/moderation/ClearChatCommand.java
+++ b/src/main/java/com/beanbeanjuice/command/moderation/ClearChatCommand.java
@@ -36,7 +36,8 @@ public class ClearChatCommand implements ICommand {
             event.getHook().sendMessageEmbeds(Helper.errorEmbed(
                     "Error Deleting Messages",
                     "There was an error deleting your messages. The " +
-                            "bot may have insufficient permissions. `" + e.getMessage() + "`"
+                            "bot may have insufficient permissions. `" + e.getMessage() + "` " +
+                            "Please click on my avatar and re-invite me to the server!"
             )).queue();
         }
     }

--- a/src/main/java/com/beanbeanjuice/utility/handler/guild/CustomGuild.java
+++ b/src/main/java/com/beanbeanjuice/utility/handler/guild/CustomGuild.java
@@ -32,8 +32,6 @@ public class CustomGuild {
     private Boolean notifyOnUpdate;
     private Boolean aiState;
 
-    private final ArrayList<TextChannel> deletingMessagesChannels;
-
     private final HashMap<CustomChannel, String> customChannelIDs;
 
     /**
@@ -84,8 +82,6 @@ public class CustomGuild {
         // Checks if a Listener has already been created for that guild.
         // This is so that if the cache is reloaded, it does not need to recreate the Listeners.
         TwitchHandler.addTwitchChannels(guildID, this.twitchChannels);
-
-        deletingMessagesChannels = new ArrayList<>();
     }
 
     /**
@@ -429,36 +425,6 @@ public class CustomGuild {
     @Nullable
     public Role getLiveNotificationsRole() {
         return GuildHandler.getGuild(guildID).getRoleById(liveNotificationsRoleID);
-    }
-
-    /**
-     * Remove a {@link TextChannel} from the list of currently deleting {@link Message}s.
-     *
-     * @param channel The {@link TextChannel} to remove.
-     */
-    public void removeTextChannelFromDeletingMessages(@NotNull TextChannel channel) {
-        deletingMessagesChannels.remove(channel);
-    }
-
-    /**
-     * Add a {@link TextChannel} to the list of currently deleting {@link Message}s.
-     *
-     * @param channel The {@link TextChannel} to add.
-     */
-    public void addTextChannelToDeletingMessages(@NotNull TextChannel channel) {
-        deletingMessagesChannels.add(channel);
-    }
-
-    /**
-     * Checks to make sure that a {@link TextChannel} does not already have {@link Message}s being
-     * currently deleted.
-     *
-     * @param channel The {@link TextChannel} to check.
-     * @return True, if it already has {@link Message}s being deleted in it.
-     */
-    @NotNull
-    public Boolean containsTextChannelDeletingMessages(@NotNull TextChannel channel) {
-        return deletingMessagesChannels.contains(channel);
     }
 
     /**


### PR DESCRIPTION
# Description

*The `/clear` command had permission errors. This has been fixed. Additionally, it now uses async deletions and no longer requires a `Java TimerTask`.*

Fixes #514

## Type of Change

- [ ] Bug Fix (Small Non-Code Breaking Issue)
- [x] Bug Fix (Critical Code Breaking Issue)
- [ ] Feature (Something New Added to the Code)
- [x] Improvement (Improving An Existing Section of Code)
- [ ] Documentation Update
- [ ] Security Vulnerability

## Changes

- [x] Internal Code
- [ ] Documentation
- [ ] Other: _____

**Test Configuration**:
* Hardware:
    - CPU: AMD Ryzen 7 3800x @ 4.125 Ghz
    - GPU: Nvidia RTX 3080
    - RAM: 32 GB DDR4 @ 3600 Mhz
* JDK: Java Oracle OpenJDK 16

# Checklist:

- [x] This pull request has been linked to the appropriate issue on GitHub. (Use the development section on the right.)
- [x] The code follows the style [guidelines](https://github.com/beanbeanjuice/cafeBot/blob/master/CONTRIBUTING.md).
- [x] A self-review of the code was performed on GitHub.
- [x] Appropriate comments and javadocs were added in your code.
- [x] Appropriate changes have been made to the documentation.
- [x] Appropriate changes have been made to the `README.md` file.
- [x] No warnings are produced when the code is run.
- [x] Appropriate tests exist for this pull request.
- [x] New and existing Maven CI tests have passed.
- [x] The pull request is properly merging into the correct branch.
- [x] All existing local code has been pushed to the GitHub repository.
- [x] Changes have been documented in the current draft [cafeBot Releases](https://github.com/beanbeanjuice/cafeBot/releases) update.